### PR TITLE
Fix issue with build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es2020"
-        ],
-        "target": "es2020",
+        "target": "es2019",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
I noticed the build was failing - it looks like this was because nullish coalescing is not available in node 12, which uses es2019. So, I dropped the typescript target down to es2019.

I also removed the manual setting of `lib`, as it [doesn't need to be set](https://www.typescriptlang.org/tsconfig#target), and can be a source of mistakes if one of `target` or `lib` is changed without the other.